### PR TITLE
Add peek and pop. Fixes #5

### DIFF
--- a/Palette.xcodeproj/project.pbxproj
+++ b/Palette.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		9273FAA91C86785000EF3DDD /* UIColor+valueExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9273FAA81C86785000EF3DDD /* UIColor+valueExtension.swift */; };
 		9279166B1CA6E6C10065773A /* InterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9279166A1CA6E6C10065773A /* InterfaceIdiom.swift */; };
 		928EA1E61C8760B500981E0D /* PaletteDetailCollectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928EA1E51C8760B500981E0D /* PaletteDetailCollectionFooterView.swift */; };
+		92B79B061E96C83800FEA387 /* PaletteView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 92B79B051E96C83800FEA387 /* PaletteView.xib */; };
+		92B79B081E96C8E600FEA387 /* PaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B79B071E96C8E600FEA387 /* PaletteView.swift */; };
 		92DF9CF31E8C965000C5D1F4 /* PaletteDetailPeekViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DF9CF21E8C965000C5D1F4 /* PaletteDetailPeekViewController.swift */; };
 		9B985148FE40243E3040916B /* Pods_Palette1_0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E74DE79569DCD3C5BA1A2FAB /* Pods_Palette1_0.framework */; };
 /* End PBXBuildFile section */
@@ -76,6 +78,8 @@
 		9273FAA81C86785000EF3DDD /* UIColor+valueExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+valueExtension.swift"; sourceTree = "<group>"; };
 		9279166A1CA6E6C10065773A /* InterfaceIdiom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceIdiom.swift; sourceTree = "<group>"; };
 		928EA1E51C8760B500981E0D /* PaletteDetailCollectionFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaletteDetailCollectionFooterView.swift; sourceTree = "<group>"; };
+		92B79B051E96C83800FEA387 /* PaletteView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PaletteView.xib; sourceTree = "<group>"; };
+		92B79B071E96C8E600FEA387 /* PaletteView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaletteView.swift; sourceTree = "<group>"; };
 		92DF9CF21E8C965000C5D1F4 /* PaletteDetailPeekViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaletteDetailPeekViewController.swift; sourceTree = "<group>"; };
 		E74DE79569DCD3C5BA1A2FAB /* Pods_Palette1_0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Palette1_0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -133,6 +137,8 @@
 				9273FA3B1C7C08B000EF3DDD /* AppDelegate.swift */,
 				9273FA9C1C84E60000EF3DDD /* Palette.swift */,
 				9273FA9A1C84BA1A00EF3DDD /* PageViewController.swift */,
+				92B79B071E96C8E600FEA387 /* PaletteView.swift */,
+				92B79B051E96C83800FEA387 /* PaletteView.xib */,
 				9273FA931C81144C00EF3DDD /* Palettes */,
 				928EA1E71C87613B00981E0D /* DetailView */,
 				924C058D1E84803A0013759B /* Camera */,
@@ -270,6 +276,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92B79B061E96C83800FEA387 /* PaletteView.xib in Resources */,
 				924C058A1E80C78D0013759B /* PalettesEmptyView.xib in Resources */,
 				9273FA461C7C08B000EF3DDD /* LaunchScreen.storyboard in Resources */,
 				9273FA431C7C08B000EF3DDD /* Assets.xcassets in Resources */,
@@ -337,6 +344,7 @@
 				9200F0461E78DE8D00C10EBD /* InspirationEmptyView.swift in Sources */,
 				9273FA631C7E109100EF3DDD /* InspirationViewController.swift in Sources */,
 				926004481E664A260086F20F /* YPMagnifyingGlass.swift in Sources */,
+				92B79B081E96C8E600FEA387 /* PaletteView.swift in Sources */,
 				926004491E664A260086F20F /* YPMagnifyingView.swift in Sources */,
 				9273FA3E1C7C08B000EF3DDD /* SwatchPickerViewController.swift in Sources */,
 				924C058C1E816E780013759B /* PalettesEmptyView.swift in Sources */,

--- a/Palette.xcodeproj/project.pbxproj
+++ b/Palette.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		9273FAA91C86785000EF3DDD /* UIColor+valueExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9273FAA81C86785000EF3DDD /* UIColor+valueExtension.swift */; };
 		9279166B1CA6E6C10065773A /* InterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9279166A1CA6E6C10065773A /* InterfaceIdiom.swift */; };
 		928EA1E61C8760B500981E0D /* PaletteDetailCollectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928EA1E51C8760B500981E0D /* PaletteDetailCollectionFooterView.swift */; };
+		92DF9CF31E8C965000C5D1F4 /* PaletteDetailPeekViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DF9CF21E8C965000C5D1F4 /* PaletteDetailPeekViewController.swift */; };
 		9B985148FE40243E3040916B /* Pods_Palette1_0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E74DE79569DCD3C5BA1A2FAB /* Pods_Palette1_0.framework */; };
 /* End PBXBuildFile section */
 
@@ -75,6 +76,7 @@
 		9273FAA81C86785000EF3DDD /* UIColor+valueExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+valueExtension.swift"; sourceTree = "<group>"; };
 		9279166A1CA6E6C10065773A /* InterfaceIdiom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceIdiom.swift; sourceTree = "<group>"; };
 		928EA1E51C8760B500981E0D /* PaletteDetailCollectionFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaletteDetailCollectionFooterView.swift; sourceTree = "<group>"; };
+		92DF9CF21E8C965000C5D1F4 /* PaletteDetailPeekViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaletteDetailPeekViewController.swift; sourceTree = "<group>"; };
 		E74DE79569DCD3C5BA1A2FAB /* Pods_Palette1_0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Palette1_0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -176,6 +178,7 @@
 			isa = PBXGroup;
 			children = (
 				9273FA6B1C7F7DD500EF3DDD /* PalettesViewController.swift */,
+				92DF9CF21E8C965000C5D1F4 /* PaletteDetailPeekViewController.swift */,
 				9273FA9E1C850DDB00EF3DDD /* PaletteCollectionViewCell.swift */,
 				924C058B1E816E780013759B /* PalettesEmptyView.swift */,
 				924C05891E80C78D0013759B /* PalettesEmptyView.xib */,
@@ -346,6 +349,7 @@
 				9279166B1CA6E6C10065773A /* InterfaceIdiom.swift in Sources */,
 				9273FAA91C86785000EF3DDD /* UIColor+valueExtension.swift in Sources */,
 				9273FA9B1C84BA1A00EF3DDD /* PageViewController.swift in Sources */,
+				92DF9CF31E8C965000C5D1F4 /* PaletteDetailPeekViewController.swift in Sources */,
 				9273FA9F1C850DDB00EF3DDD /* PaletteCollectionViewCell.swift in Sources */,
 				9273FA9D1C84E60000EF3DDD /* Palette.swift in Sources */,
 				9273FA6E1C7F88DD00EF3DDD /* BackgroundImage.swift in Sources */,

--- a/Palette/Base.lproj/Main.storyboard
+++ b/Palette/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="fne-c8-XAh">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="fne-c8-XAh">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -240,44 +240,35 @@
         <!--Palette Detail Peek View Controller-->
         <scene sceneID="Xwo-mf-Z4n">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="p3l-8d-Wdd" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <viewController storyboardIdentifier="PaletteDetailPeekViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="RLi-rH-8tO" customClass="PaletteDetailPeekViewController" customModule="Palette" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="CNc-ag-vDD"/>
                         <viewControllerLayoutGuide type="bottom" id="anD-th-L2j"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="KjV-RO-oRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="425"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="db4-Vz-wcB">
-                                <rect key="frame" x="20" y="20" width="335" height="335"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="db4-Vz-wcB" secondAttribute="height" multiplier="1:1" id="R9Y-uM-xyZ"/>
-                                </constraints>
-                            </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="7yJ-SN-hLg">
-                                <rect key="frame" x="20" y="355" width="335" height="50"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="50" id="UtG-LH-7ab"/>
-                                </constraints>
-                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JpV-H9-7Dl">
+                                <rect key="frame" x="20" y="20" width="335" height="385"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            </view>
                         </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="anD-th-L2j" firstAttribute="top" relation="greaterThanOrEqual" secondItem="7yJ-SN-hLg" secondAttribute="bottom" constant="20" id="3JO-CF-ifr"/>
-                            <constraint firstItem="db4-Vz-wcB" firstAttribute="top" secondItem="KjV-RO-oRQ" secondAttribute="top" constant="20" id="3YB-fj-6C2"/>
-                            <constraint firstAttribute="trailing" secondItem="db4-Vz-wcB" secondAttribute="trailing" constant="20" id="3xB-uE-q6k"/>
-                            <constraint firstItem="7yJ-SN-hLg" firstAttribute="leading" secondItem="KjV-RO-oRQ" secondAttribute="leading" constant="20" id="7gC-Fv-Grk"/>
-                            <constraint firstAttribute="trailing" secondItem="7yJ-SN-hLg" secondAttribute="trailing" constant="20" id="Bha-TT-Pp2"/>
-                            <constraint firstItem="7yJ-SN-hLg" firstAttribute="top" secondItem="db4-Vz-wcB" secondAttribute="bottom" id="WHo-na-7Es"/>
-                            <constraint firstItem="db4-Vz-wcB" firstAttribute="leading" secondItem="KjV-RO-oRQ" secondAttribute="leading" constant="20" id="rQh-0v-CgV"/>
+                            <constraint firstItem="anD-th-L2j" firstAttribute="top" secondItem="JpV-H9-7Dl" secondAttribute="bottom" constant="20" id="5Ia-a3-UoW"/>
+                            <constraint firstItem="JpV-H9-7Dl" firstAttribute="top" secondItem="KjV-RO-oRQ" secondAttribute="top" constant="20" id="STX-wH-eTj"/>
+                            <constraint firstAttribute="trailing" secondItem="JpV-H9-7Dl" secondAttribute="trailing" constant="20" id="ihf-47-HUA"/>
+                            <constraint firstItem="JpV-H9-7Dl" firstAttribute="leading" secondItem="KjV-RO-oRQ" secondAttribute="leading" constant="20" id="ph2-NL-tAY"/>
                         </constraints>
                     </view>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="375" height="425"/>
                     <connections>
-                        <outlet property="imageView" destination="db4-Vz-wcB" id="spC-LK-tyD"/>
-                        <outlet property="stackView" destination="7yJ-SN-hLg" id="Xwt-zl-1Kh"/>
+                        <outlet property="containerView" destination="JpV-H9-7Dl" id="3oE-t0-JgT"/>
                     </connections>
                 </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="p3l-8d-Wdd" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1461.5999999999999" y="1563.8680659670167"/>
         </scene>

--- a/Palette/Base.lproj/Main.storyboard
+++ b/Palette/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="fne-c8-XAh">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="fne-c8-XAh">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -14,7 +14,7 @@
         <!--Palette Detail View Controller-->
         <scene sceneID="QOQ-TV-N3I">
             <objects>
-                <viewController id="3AH-J5-fNk" customClass="PaletteDetailViewController" customModule="Palette" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PaletteDetailViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="3AH-J5-fNk" customClass="PaletteDetailViewController" customModule="Palette" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="P2h-0b-MKI"/>
                         <viewControllerLayoutGuide type="bottom" id="Cv3-W6-1TO"/>
@@ -143,10 +143,10 @@
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dj5-aI-Ubr">
-                                            <rect key="frame" x="20" y="0.0" width="280" height="60"/>
+                                            <rect key="frame" x="20" y="0.0" width="335" height="60"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HMT-Zt-xat">
-                                                    <rect key="frame" x="40" y="5" width="200" height="50"/>
+                                                    <rect key="frame" x="40" y="5" width="255" height="50"/>
                                                     <fontDescription key="fontDescription" name="Menlo-Regular" family="Menlo" pointSize="17"/>
                                                     <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <state key="normal" title="Delete" image="ic_delete_forever"/>
@@ -235,7 +235,51 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nUY-Jg-20i" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-64" y="1647"/>
+            <point key="canvasLocation" x="673" y="1564"/>
+        </scene>
+        <!--Palette Detail Peek View Controller-->
+        <scene sceneID="Xwo-mf-Z4n">
+            <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="p3l-8d-Wdd" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <viewController storyboardIdentifier="PaletteDetailPeekViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="RLi-rH-8tO" customClass="PaletteDetailPeekViewController" customModule="Palette" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="CNc-ag-vDD"/>
+                        <viewControllerLayoutGuide type="bottom" id="anD-th-L2j"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="KjV-RO-oRQ">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="db4-Vz-wcB">
+                                <rect key="frame" x="20" y="20" width="335" height="335"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="db4-Vz-wcB" secondAttribute="height" multiplier="1:1" id="R9Y-uM-xyZ"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="7yJ-SN-hLg">
+                                <rect key="frame" x="20" y="355" width="335" height="50"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="UtG-LH-7ab"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="anD-th-L2j" firstAttribute="top" relation="greaterThanOrEqual" secondItem="7yJ-SN-hLg" secondAttribute="bottom" constant="20" id="3JO-CF-ifr"/>
+                            <constraint firstItem="db4-Vz-wcB" firstAttribute="top" secondItem="KjV-RO-oRQ" secondAttribute="top" constant="20" id="3YB-fj-6C2"/>
+                            <constraint firstAttribute="trailing" secondItem="db4-Vz-wcB" secondAttribute="trailing" constant="20" id="3xB-uE-q6k"/>
+                            <constraint firstItem="7yJ-SN-hLg" firstAttribute="leading" secondItem="KjV-RO-oRQ" secondAttribute="leading" constant="20" id="7gC-Fv-Grk"/>
+                            <constraint firstAttribute="trailing" secondItem="7yJ-SN-hLg" secondAttribute="trailing" constant="20" id="Bha-TT-Pp2"/>
+                            <constraint firstItem="7yJ-SN-hLg" firstAttribute="top" secondItem="db4-Vz-wcB" secondAttribute="bottom" id="WHo-na-7Es"/>
+                            <constraint firstItem="db4-Vz-wcB" firstAttribute="leading" secondItem="KjV-RO-oRQ" secondAttribute="leading" constant="20" id="rQh-0v-CgV"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="imageView" destination="db4-Vz-wcB" id="spC-LK-tyD"/>
+                        <outlet property="stackView" destination="7yJ-SN-hLg" id="Xwt-zl-1Kh"/>
+                    </connections>
+                </viewController>
+            </objects>
+            <point key="canvasLocation" x="1461.5999999999999" y="1563.8680659670167"/>
         </scene>
         <!--Swatch Picker View Controller-->
         <scene sceneID="tne-QT-ifu">
@@ -402,7 +446,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-842.39999999999998" y="1646.6266866566718"/>
+            <point key="canvasLocation" x="-468" y="1564"/>
         </scene>
         <!--Palettes View Controller-->
         <scene sceneID="2Ed-7H-UrH">
@@ -458,7 +502,7 @@
                                             <constraint firstItem="r3T-1i-tsm" firstAttribute="leading" secondItem="LEC-hi-ivQ" secondAttribute="leading" constant="5" id="qta-mF-yFX"/>
                                         </constraints>
                                         <connections>
-                                            <outlet property="containerView" destination="r3T-1i-tsm" id="Ffd-su-nHP"/>
+                                            <outlet property="containerView" destination="r3T-1i-tsm" id="Jn7-Ux-Kfx"/>
                                             <outlet property="paletteStackView" destination="iGZ-Y4-b8a" id="bdS-jc-1Ke"/>
                                             <segue destination="3AH-J5-fNk" kind="showDetail" identifier="ShowPaletteDetail" id="a3g-xD-5uO"/>
                                         </connections>
@@ -501,11 +545,12 @@
                     <connections>
                         <outlet property="headerView" destination="Z69-DV-XSE" id="Vn1-cV-niP"/>
                         <outlet property="paletteCollectionView" destination="gPr-Yx-ULQ" id="S2s-GP-9G4"/>
+                        <segue destination="RLi-rH-8tO" kind="presentation" identifier="ShowPaletteDetailPreview" id="MRi-wn-lUc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IvP-Dj-Doz" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-63.200000000000003" y="803.74812593703155"/>
+            <point key="canvasLocation" x="673" y="804"/>
         </scene>
         <!--Page View Controller-->
         <scene sceneID="Rjc-xR-Qs0">
@@ -627,7 +672,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ya1-Il-GWz" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-839.20000000000005" y="803.74812593703155"/>
+            <point key="canvasLocation" x="-810" y="804"/>
         </scene>
         <!--Inspiration View Controller-->
         <scene sceneID="VhH-za-aNE">
@@ -730,7 +775,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0PM-GQ-fwK" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="717.60000000000002" y="803.74812593703155"/>
+            <point key="canvasLocation" x="-127" y="804"/>
         </scene>
     </scenes>
     <resources>

--- a/Palette/Palette.swift
+++ b/Palette/Palette.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-
 final class Palette: NSObject, NSCoding {
     var colors: [UIColor]!
     var imageURL: String!

--- a/Palette/Palette.swift
+++ b/Palette/Palette.swift
@@ -32,3 +32,22 @@ final class Palette: NSObject, NSCoding {
         aCoder.encode(self.imageURL, forKey: "imageURL")
     }
 }
+
+
+extension Palette {
+    func shareableImage() -> UIImage? {
+        guard let view = PaletteView.instanceFromNib() as? PaletteView else { return nil }
+        view.frame = CGRect(x: 0, y: 0, width: 355, height: 415)
+        view.update(with: self)
+        
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        
+        UIGraphicsBeginImageContextWithOptions(view.frame.size, view.isOpaque, 0.0)
+        view.layer.render(in: UIGraphicsGetCurrentContext()!)
+        
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
+    }
+}

--- a/Palette/PaletteCollectionViewCell.swift
+++ b/Palette/PaletteCollectionViewCell.swift
@@ -8,12 +8,14 @@
 
 import UIKit
 
-class PaletteCollectionViewCell: UICollectionViewCell {
-    @IBOutlet var containerView: UIView!
-    @IBOutlet var paletteStackView: UIStackView!
-    var palette: Palette!
+final class PaletteCollectionViewCell: UICollectionViewCell {
+    @IBOutlet private var containerView: UIView!
+    @IBOutlet private var paletteStackView: UIStackView!
     
-    func populatePalette () {
+    func setup(with palette: Palette) {
+        containerView.layer.cornerRadius = 6
+        containerView.clipsToBounds = true
+
         for view in paletteStackView.subviews {
             paletteStackView.removeArrangedSubview(view)
         }

--- a/Palette/PaletteDetailCollectionFooterView.swift
+++ b/Palette/PaletteDetailCollectionFooterView.swift
@@ -8,6 +8,6 @@
 
 import UIKit
 
-class PaletteDetailCollectionFooterView: UICollectionReusableView {
+final class PaletteDetailCollectionFooterView: UICollectionReusableView {
     @IBOutlet var containerView: UIView!
 }

--- a/Palette/PaletteDetailCollectionReusableView.swift
+++ b/Palette/PaletteDetailCollectionReusableView.swift
@@ -8,8 +8,29 @@
 
 import UIKit
 
-class PaletteDetailCollectionReusableView: UICollectionReusableView {
+final class PaletteDetailCollectionReusableView: UICollectionReusableView {
+    @IBOutlet private var imageView: UIImageView!
+    @IBOutlet private var stackView: UIStackView!
+    
     @IBOutlet var containerView: UIView!
-    @IBOutlet var imageView: UIImageView!
-    @IBOutlet var stackView: UIStackView!
+    
+    func setup(with palette: Palette) {
+        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let fileURL = documentsURL.appendingPathComponent(palette.imageURL)
+        if let data = try? Data(contentsOf: fileURL) {
+            imageView.image = UIImage(data: data)
+        }
+        
+        if stackView.arrangedSubviews.count > 0 {
+            for view in stackView.arrangedSubviews {
+                stackView.removeArrangedSubview(view)
+            }
+        }
+        
+        for color in palette.colors {
+            let view = UIView()
+            view.backgroundColor = color
+            stackView.addArrangedSubview(view)
+        }
+    }
 }

--- a/Palette/PaletteDetailCollectionViewCell.swift
+++ b/Palette/PaletteDetailCollectionViewCell.swift
@@ -8,8 +8,15 @@
 
 import UIKit
 
-class PaletteDetailCollectionViewCell: UICollectionViewCell {
-    @IBOutlet var colorView: UIView!
-    @IBOutlet var hexLabel: UILabel!
-    @IBOutlet var RGBLabel: UILabel!
+final class PaletteDetailCollectionViewCell: UICollectionViewCell {
+    @IBOutlet private var colorView: UIView!
+    @IBOutlet private var hexLabel: UILabel!
+    @IBOutlet private var RGBLabel: UILabel!
+    
+    func setup(with color: UIColor) {
+        colorView.layer.cornerRadius = colorView.frame.size.height / 2.0
+        colorView.backgroundColor = color
+        hexLabel.text = color.hexString()
+        RGBLabel.text = color.rgbString()
+    }
 }

--- a/Palette/PaletteDetailPeekViewController.swift
+++ b/Palette/PaletteDetailPeekViewController.swift
@@ -13,6 +13,7 @@ final class PaletteDetailPeekViewController: UIViewController {
     
     var palette: Palette?
     var shareAction: (() -> ())?
+    var deleteAction: (() -> ())?
     
     private lazy var paletteView: PaletteView = {
         let view = PaletteView.instanceFromNib()
@@ -26,7 +27,7 @@ final class PaletteDetailPeekViewController: UIViewController {
         })
         
         let deleteAction = UIPreviewAction(title: NSLocalizedString("Delete", comment: ""), style: .destructive, handler: { (previewAction, viewController) -> Void in
-            
+            self.deleteAction?()
         })
         
         return [shareAction, deleteAction]

--- a/Palette/PaletteDetailPeekViewController.swift
+++ b/Palette/PaletteDetailPeekViewController.swift
@@ -1,0 +1,66 @@
+//
+//  PaletteDetailPeekViewController.swift
+//  Palette
+//
+//  Created by Alex Mathers on 2017-03-29.
+//  Copyright © 2017 Malecks. All rights reserved.
+//
+
+import UIKit
+
+final class PaletteDetailPeekViewController: UIViewController {
+    @IBOutlet private weak var imageView: UIImageView!
+    @IBOutlet private weak var stackView: UIStackView!
+    
+    var palette: Palette?
+    
+    lazy var previewActions: [UIPreviewActionItem] = {
+        let shareAction = UIPreviewAction(title: NSLocalizedString("Share Palette", comment: ""), style: .default, handler: { (previewAction, viewController) -> Void in
+            
+        })
+        
+        let deleteAction = UIPreviewAction(title: NSLocalizedString("Delete", comment: ""), style: .destructive, handler: { (previewAction, viewController) -> Void in
+            
+        })
+        
+        return [shareAction, deleteAction]
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+    }
+    
+    private func setupView() {
+        guard let palette = palette else { return }
+        
+        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let fileURL = documentsURL.appendingPathComponent(palette.imageURL)
+        if let data = try? Data(contentsOf: fileURL) {
+            imageView.image = UIImage(data: data)
+        }
+        
+        if stackView.arrangedSubviews.count > 0 {
+            for view in stackView.arrangedSubviews {
+                stackView.removeArrangedSubview(view)
+            }
+        }
+        
+        for color in palette.colors {
+            let view = UIView()
+            view.backgroundColor = color
+            stackView.addArrangedSubview(view)
+        }
+        
+        if let colors = palette.colors {
+            if colors.count > 0 {
+                let randomNum: Int = Int(arc4random_uniform(UInt32(colors.count)))
+                let randomColour = colors[randomNum]
+                let backgroundView = UIImageView(frame: view.frame)
+                let backgroundImage = UIImage().createBackgroundImageWithColor(randomColour)
+                backgroundView.image = backgroundImage
+                view.insertSubview(backgroundView, at: 0)
+            }
+        }
+    }
+}

--- a/Palette/PaletteDetailPeekViewController.swift
+++ b/Palette/PaletteDetailPeekViewController.swift
@@ -9,14 +9,20 @@
 import UIKit
 
 final class PaletteDetailPeekViewController: UIViewController {
-    @IBOutlet private weak var imageView: UIImageView!
-    @IBOutlet private weak var stackView: UIStackView!
+    @IBOutlet private weak var containerView: UIView!
     
     var palette: Palette?
+    var shareAction: (() -> ())?
+    
+    private lazy var paletteView: PaletteView = {
+        let view = PaletteView.instanceFromNib()
+        view?.translatesAutoresizingMaskIntoConstraints = false
+        return view as! PaletteView
+    }()
     
     lazy var previewActions: [UIPreviewActionItem] = {
         let shareAction = UIPreviewAction(title: NSLocalizedString("Share Palette", comment: ""), style: .default, handler: { (previewAction, viewController) -> Void in
-            
+            self.shareAction?()
         })
         
         let deleteAction = UIPreviewAction(title: NSLocalizedString("Delete", comment: ""), style: .destructive, handler: { (previewAction, viewController) -> Void in
@@ -34,24 +40,6 @@ final class PaletteDetailPeekViewController: UIViewController {
     private func setupView() {
         guard let palette = palette else { return }
         
-        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        let fileURL = documentsURL.appendingPathComponent(palette.imageURL)
-        if let data = try? Data(contentsOf: fileURL) {
-            imageView.image = UIImage(data: data)
-        }
-        
-        if stackView.arrangedSubviews.count > 0 {
-            for view in stackView.arrangedSubviews {
-                stackView.removeArrangedSubview(view)
-            }
-        }
-        
-        for color in palette.colors {
-            let view = UIView()
-            view.backgroundColor = color
-            stackView.addArrangedSubview(view)
-        }
-        
         if let colors = palette.colors {
             if colors.count > 0 {
                 let randomNum: Int = Int(arc4random_uniform(UInt32(colors.count)))
@@ -62,5 +50,25 @@ final class PaletteDetailPeekViewController: UIViewController {
                 view.insertSubview(backgroundView, at: 0)
             }
         }
+        
+        containerView.addSubview(paletteView)
+        
+        containerView.addConstraints(NSLayoutConstraint.constraints(
+                withVisualFormat: "V:|[paletteView]|",
+                options: NSLayoutFormatOptions(),
+                metrics: nil,
+                views: ["paletteView" : paletteView]))
+        
+        containerView.addConstraints(NSLayoutConstraint.constraints(
+                withVisualFormat: "H:|[paletteView]|",
+                options: NSLayoutFormatOptions(),
+                metrics: nil,
+                views: ["paletteView" : paletteView]
+        ))
+        
+        paletteView.update(with: palette)
+        
+        containerView.layer.cornerRadius = 9
+        containerView.clipsToBounds = true
     }
 }

--- a/Palette/PaletteView.swift
+++ b/Palette/PaletteView.swift
@@ -1,0 +1,49 @@
+//
+//  PaletteView.swift
+//  Palette
+//
+//  Created by Alex Mathers on 2017-04-06.
+//  Copyright © 2017 Malecks. All rights reserved.
+//
+
+import UIKit
+
+final class PaletteView: UIView {
+    
+    @IBOutlet private weak var imageView: UIImageView!
+    @IBOutlet private weak var stackView: UIStackView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    func update(with palette: Palette) {
+        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let fileURL = documentsURL.appendingPathComponent(palette.imageURL)
+        if let data = try? Data(contentsOf: fileURL) {
+            imageView.image = UIImage(data: data)
+        }
+        
+        if stackView.arrangedSubviews.count > 0 {
+            for view in stackView.arrangedSubviews {
+                stackView.removeArrangedSubview(view)
+            }
+        }
+        
+        for color in palette.colors {
+            let view = UIView()
+            view.backgroundColor = color
+            stackView.addArrangedSubview(view)
+        }
+    }
+    
+    class func instanceFromNib() -> UIView? {
+        let nib = UINib(nibName: "PaletteView", bundle: nil).instantiate(withOwner: nil, options: nil)
+        for view in nib {
+            if let view = view as? PaletteView {
+                return view
+            }
+        }
+        return nil
+    }
+}

--- a/Palette/PaletteView.xib
+++ b/Palette/PaletteView.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="PaletteView" customModule="Palette" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="355" height="415"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jFW-P0-cS3">
+                    <rect key="frame" x="0.0" y="0.0" width="355" height="355"/>
+                    <constraints>
+                        <constraint firstAttribute="width" secondItem="jFW-P0-cS3" secondAttribute="height" multiplier="1:1" id="tZM-cU-umN"/>
+                    </constraints>
+                </imageView>
+                <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="s18-Ne-saq">
+                    <rect key="frame" x="0.0" y="355" width="355" height="60"/>
+                    <constraints>
+                        <constraint firstAttribute="height" priority="750" constant="60" id="zc6-QD-CkV"/>
+                    </constraints>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="jFW-P0-cS3" secondAttribute="trailing" id="8iw-yi-W63"/>
+                <constraint firstItem="s18-Ne-saq" firstAttribute="top" secondItem="jFW-P0-cS3" secondAttribute="bottom" id="FnB-Fj-dqU"/>
+                <constraint firstAttribute="bottom" secondItem="s18-Ne-saq" secondAttribute="bottom" id="TPV-6O-NPc"/>
+                <constraint firstItem="s18-Ne-saq" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="cDX-AQ-WR6"/>
+                <constraint firstAttribute="trailing" secondItem="s18-Ne-saq" secondAttribute="trailing" id="dXL-8W-Obx"/>
+                <constraint firstItem="jFW-P0-cS3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="fYB-R5-hXu"/>
+                <constraint firstItem="jFW-P0-cS3" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="n3Y-Yu-zyE"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="imageView" destination="jFW-P0-cS3" id="qkd-UL-ZkI"/>
+                <outlet property="stackView" destination="s18-Ne-saq" id="bOB-UI-0la"/>
+            </connections>
+            <point key="canvasLocation" x="25.5" y="52.5"/>
+        </view>
+    </objects>
+</document>

--- a/Palette/PalettesEmptyView.swift
+++ b/Palette/PalettesEmptyView.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class PalettesEmptyView: UIView {
+final class PalettesEmptyView: UIView {
 
-    @IBOutlet weak var containerView: UIView!
+    @IBOutlet private weak var containerView: UIView!
     
     var cameraButtonAction: (() -> ())?
     var inspirationButtonAction: (() -> ())?
@@ -20,15 +20,14 @@ class PalettesEmptyView: UIView {
         containerView.layer.cornerRadius = 9
     }
 
-    @IBAction func didTapCameraButton() {
+    @IBAction private func didTapCameraButton() {
         cameraButtonAction?()
     }
     
     
-    @IBAction func didTapInspirationButton() {
+    @IBAction private func didTapInspirationButton() {
         inspirationButtonAction?()
     }
-    
     
     class func instanceFromNib() -> UIView? {
         let nib = UINib(nibName: "PalettesEmptyView", bundle: nil).instantiate(withOwner: nil, options: nil)

--- a/Palette/PalettesViewController.swift
+++ b/Palette/PalettesViewController.swift
@@ -134,6 +134,12 @@ extension PalettesViewController: UIViewControllerPreviewingDelegate {
             let viewController = storyboard?.instantiateViewController(withIdentifier: "PaletteDetailPeekViewController") as? PaletteDetailPeekViewController else { return nil }
         
         viewController.palette =  palettes[indexPath.row]
+        viewController.shareAction = {
+            guard let snapshot = self.palettes[indexPath.row].shareableImage() else { return }
+            let activityVC = UIActivityViewController(activityItems: [snapshot], applicationActivities: nil)
+            self.present(activityVC, animated: true, completion: nil)
+        }
+        
         viewController.preferredContentSize = CGSize(width: 355, height: 405)
         previewingContext.sourceRect = paletteCollectionView.convert(cell.frame, to: paletteCollectionView.superview!)
         

--- a/Palette/PalettesViewController.swift
+++ b/Palette/PalettesViewController.swift
@@ -9,8 +9,8 @@
 import UIKit
 import DZNEmptyDataSet
 
-class PalettesViewController: UIViewController {
-    fileprivate var arrayOfPalettes: Array<Palette> = []
+final class PalettesViewController: UIViewController {
+    fileprivate var palettes: Array<Palette> = []
     @IBOutlet fileprivate var paletteCollectionView: UICollectionView!
     @IBOutlet private var headerView: UIView!
     
@@ -28,6 +28,10 @@ class PalettesViewController: UIViewController {
         paletteCollectionView.emptyDataSetSource = self
         paletteCollectionView.emptyDataSetDelegate = self
         setupView()
+        
+        if traitCollection.forceTouchCapability == .available {
+            registerForPreviewing(with: self, sourceView: view)
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -36,7 +40,7 @@ class PalettesViewController: UIViewController {
         paletteCollectionView.reloadData()
     }
     
-    func setupView () {
+    private func setupView () {
         emptyView.cameraButtonAction = {
             self.showCameraView?()
         }
@@ -52,29 +56,33 @@ class PalettesViewController: UIViewController {
     }
     
     private func setUpPalettes () {
-        arrayOfPalettes = []
+        palettes = []
         let defaults = UserDefaults.standard
         if let encodedArray = defaults.object(forKey: "palettesArray") as? [Data] {
             for data in encodedArray {
                 if let palette: Palette = NSKeyedUnarchiver.unarchiveObject(with: data) as? Palette {
-                    arrayOfPalettes.append(palette)
+                    palettes.append(palette)
                 }
             }
         }
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "ShowPaletteDetail" {
+        if segue.identifier == "ShowPaletteDetail" || segue.identifier == "ShowPaletteDetailPreview" {
             if let dvc = segue.destination as? PaletteDetailViewController {
-                let cell = sender as! PaletteCollectionViewCell
-                dvc.palette = cell.palette
-                dvc.paletteIndex = paletteCollectionView.indexPath(for: cell)!.row
+                guard let cell = sender as? PaletteCollectionViewCell,
+                    let indexPath = paletteCollectionView.indexPath(for: cell) else {
+                        return
+                }
+                
+                dvc.palette = palettes[indexPath.row]
+                dvc.paletteIndex = indexPath.row
             }
         }
     }
     
     func scrollToTop() {
-        guard arrayOfPalettes.count > 0 else { return }
+        guard palettes.count > 0 else { return }
         self.paletteCollectionView.scrollToItem(
             at: IndexPath(row: 0, section: 0),
             at: UICollectionViewScrollPosition.centeredVertically,
@@ -85,19 +93,13 @@ class PalettesViewController: UIViewController {
 
 extension PalettesViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return arrayOfPalettes.count
+        return palettes.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "PaletteCell", for: indexPath) as! PaletteCollectionViewCell
-        let palette = arrayOfPalettes[indexPath.row]
-        
-        cell.palette = palette
-        cell.populatePalette()
-        
         cell.layer.cornerRadius = 9
-        cell.containerView.clipsToBounds = true
-        cell.containerView.layer.cornerRadius = 4
+        cell.setup(with: palettes[indexPath.row])
         return cell
     }
 }
@@ -123,4 +125,26 @@ extension PalettesViewController: DZNEmptyDataSetSource {
 
 extension PalettesViewController: DZNEmptyDataSetDelegate {
     
+}
+
+extension PalettesViewController: UIViewControllerPreviewingDelegate {
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
+        guard let indexPath = paletteCollectionView.indexPathForItem(at: paletteCollectionView.convert(location, from: view)),
+            let cell = paletteCollectionView.cellForItem(at: indexPath),
+            let viewController = storyboard?.instantiateViewController(withIdentifier: "PaletteDetailPeekViewController") as? PaletteDetailPeekViewController else { return nil }
+        
+        viewController.palette =  palettes[indexPath.row]
+        viewController.preferredContentSize = CGSize(width: 355, height: 405)
+        previewingContext.sourceRect = paletteCollectionView.convert(cell.frame, to: paletteCollectionView.superview!)
+        
+        return viewController
+    }
+    
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
+        guard let viewController = viewControllerToCommit as? PaletteDetailPeekViewController,
+            let detailViewController = storyboard?.instantiateViewController(withIdentifier: "PaletteDetailViewController") as? PaletteDetailViewController else { return }
+        detailViewController.palette = viewController.palette
+        
+        show(detailViewController, sender: self)
+    }
 }

--- a/Palette/UIColor+valueExtension.swift
+++ b/Palette/UIColor+valueExtension.swift
@@ -10,15 +10,18 @@ import UIKit
 
 extension UIColor {
     func hexString() -> String {
-        let hexString = String(format: "%02X%02X%02X",
-            Int((self.cgColor.components?[0])! * 255.0),
-            Int((self.cgColor.components?[1])! * 255.0),
-            Int((self.cgColor.components?[2])! * 255.0))
-        return hexString
+        
+        guard let components = self.cgColor.components,
+        components.count >= 3 else { return "" }
+        let r = Int(components[0] * 255.0)
+        let g = Int(components[1] * 255.0)
+        let b = Int(components[2] * 255.0)
+        
+        return String(format: "#%02X%02X%02X", r, g, b)
     }
     
     
-    func rgbString() -> String? {
+    func rgbString() -> String {
         var fRed : CGFloat = 0
         var fGreen : CGFloat = 0
         var fBlue : CGFloat = 0
@@ -32,8 +35,7 @@ extension UIColor {
             let rgbString = "R:\(iRed) G:\(iGreen) B:\(iBlue)"
             return rgbString
         } else {
-            // Could not extract RGBA components:
-            return nil
+            return ""
         }
     }
 }


### PR DESCRIPTION
Add peek and pop behaviour to Palettes view.
- added `PaletteDetailPeekViewController`
- added `PaletteView`
- added `shareableImage()` function on `Palette`
- implemented peek and pop behaviour for palettes in the `PaletteViewController`
  - soft pressing a palette will display a `PaletteView` inside on a background generated with one of the palette's colors.
  - hard pressing will take you to the `PaletteDetailViewController`
  - two actions are presented from the peek view
    - Share: will use a new class method on `Palette` to create an image from a new instance of `PaletteView` and present the default iOS share sheet
    - Delete: will present a confirmation dialogue; on confirmation Palette is deleted from user prefs and collection view